### PR TITLE
Add files to `clobber`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,4 +13,13 @@ require 'yard'
 
 YARD::Rake::YardocTask.new
 
+CLOBBER.include(
+  # RSpec generated files
+  File.join('spec', 'reports'),
+  File.join('.rspec_status'),
+  # YARD generated files
+  File.join('.yardoc'),
+  File.join('doc')
+)
+
 task default: %i[spec rubocop yard]


### PR DESCRIPTION
These files could also be added to `clean`, but according to the documentation `clean` is for "scratch files and backup files", and the proper definition include stuff like `*~` and `.bak`.